### PR TITLE
Fix package

### DIFF
--- a/on-parens.el
+++ b/on-parens.el
@@ -153,7 +153,7 @@
      (interactive "p")
      (if (< arg 0)
          (,opposite (abs arg))
-       (dotimes (i arg)
+       (dotimes (_i arg)
          (,command)))))
 
 (defun on-parens--forward-sexp-from-on-open ()

--- a/on-parens.el
+++ b/on-parens.el
@@ -4,7 +4,7 @@
 
 ;; Author:  William G Hatch
 ;; Keywords: evil, smartparens
-;; Package-Requires: ((dash "2.10.0") (emacs "24") (evil "1.1.6") (smartparens "1.6.3"))
+;; Package-Requires: ((dash "2.10.0") (emacs "24") (evil "1.1.6") (smartparens "1.6.3") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -40,13 +40,14 @@
 (require 'dash)
 (require 'smartparens)
 (require 'evil) ; for evil-jump-item
+(require 'cl-lib)
 
 (defun on-parens--get-specs (sp-def)
   ;; return a list of smartparen specs that are global or for an active mode
   (let ((mode (car sp-def)))
     (if (or
-         (equalp t mode)
-         (equalp mode major-mode)
+         (cl-equalp t mode)
+         (cl-equalp mode major-mode)
          (-contains? minor-mode-list mode))
         (cdr sp-def)
       nil)))
@@ -54,7 +55,7 @@
   ;; get the delimiter from the spec
   (let ((kw (if open? :open :close)))
     (cond ((not sp-spec) nil)
-          ((equalp (car sp-spec) kw) (cadr sp-spec))
+          ((cl-equalp (car sp-spec) kw) (cadr sp-spec))
           (t (on-parens--get-delim-from-spec (cdr sp-spec) open?)))))
 
 (defun on-parens--delim-list (open?)
@@ -94,7 +95,7 @@
 (defun on-parens--movements-equal? (a b)
   (let ((am (save-excursion (funcall a) (point)))
         (bm (save-excursion (funcall b) (point))))
-    (equalp am bm)))
+    (cl-equalp am bm)))
 
 (defun on-parens--from-close-on-last-sexp? ()
   (on-parens--movements-equal?

--- a/on-parens.el
+++ b/on-parens.el
@@ -110,7 +110,7 @@
 (defun on-parens--on-last-sexp? ()
   (cond ((on-parens-on-open?) (on-parens--from-open-on-last-sexp?))
         ((on-parens-on-close?) (on-parens--from-close-on-last-sexp?))
-        (t (on-parens-on-last-symbol-sexp?))))
+        (t (on-parens--on-last-symbol-sexp?))))
 
 (defun on-parens--from-open-on-first-sexp? ()
   (on-parens--advances? 'sp-previous-sexp t))


### PR DESCRIPTION
- Correct function name
- Suppress byte-compile warning about unused lexical variable
- Load cl-lib.el for using cl-equalp

```
on-parens.el:175:1:Warning: Unused lexical variable `i'
on-parens.el:195:1:Warning: Unused lexical variable `i'
on-parens.el:216:1:Warning: Unused lexical variable `i'
on-parens.el:239:1:Warning: Unused lexical variable `i'
on-parens.el:248:1:Warning: Unused lexical variable `i'
on-parens.el:257:1:Warning: Unused lexical variable `i'
on-parens.el:265:1:Warning: Unused lexical variable `i'
on-parens.el:273:1:Warning: Unused lexical variable `i'
on-parens.el:286:1:Warning: Unused lexical variable `i'
on-parens.el:290:1:Warning: Unused lexical variable `i'

In end of data:
on-parens.el:336:1:Warning: the following functions are not known to be defined: equalp,
    on-parens-on-last-symbol-sexp?
```
